### PR TITLE
Ignore readings less than the sensor's minimum range

### DIFF
--- a/include/open_karto/Karto.h
+++ b/include/open_karto/Karto.h
@@ -5838,6 +5838,7 @@ namespace karto
     {
       kt_double rangeThreshold = pScan->GetLaserRangeFinder()->GetRangeThreshold();
       kt_double maxRange = pScan->GetLaserRangeFinder()->GetMaximumRange();
+      kt_double minRange = pScan->GetLaserRangeFinder()->GetMinimumRange();
 
       Vector2<kt_double> scanPosition = pScan->GetSensorPose().GetPosition();
 
@@ -5854,9 +5855,9 @@ namespace karto
         kt_double rangeReading = pScan->GetRangeReadings()[pointIndex];
         kt_bool isEndPointValid = rangeReading < (rangeThreshold - KT_TOLERANCE);
 
-        if (rangeReading >= maxRange || isnan(rangeReading))
+        if (rangeReading <= minRange || rangeReading >= maxRange || isnan(rangeReading))
         {
-          // ignore max range readings
+          // ignore these readings
           pointIndex++;
           continue;
         }


### PR DESCRIPTION
If a `LaserScan` message contains range readings that are below the sensor's minimum range, Karto will still use them for mapping purposes, resulting in situations like the one in the screenshot below, where the red arrow is the robot's initial pose, `[0 0 0]` More details on this issue can be found here: http://answers.ros.org/question/232523

<img width="1550" alt="screen shot 2016-04-21 at 10 40 48 am" src="https://cloud.githubusercontent.com/assets/2285973/14724100/330d50fc-07e2-11e6-91a9-e207216a0301.png">

Even though Karto does have filtering capabilities:

``` cpp
inline const PointVectorDouble& GetPointReadings(kt_bool wantFiltered = false) const
```

they are not used. All calls to `GetPointReadings` are without `wantFiltered = true`. So, one way to address the issue would be to do `pScan->GetPointReadings(true)` in the function `AddScan`. However, since there's already some filtering logic in `AddScan`, I just added another condition to the if statement. (There is a slight difference between the two solutions. I went with the one that, imo, will have minimal side effects.)
