### PR TITLE
Process scan if enough time has elapsed since the previous one

### DIFF
--- a/include/open_karto/Mapper.h
+++ b/include/open_karto/Mapper.h
@@ -1710,6 +1710,19 @@ namespace karto
     Parameter<kt_bool>* m_pUseScanBarycenter;
 
     /**
+     * Sets the minimum time between scans. If a new scan's time stamp is
+     * longer than MinimumTimeInterval from the previously processed scan,
+     * the mapper will use the data from the new scan. Otherwise, it will
+     * discard the new scan if it also does not meet the minimum travel
+     * distance and heading requirements. For performance reasons, it is
+     * generally it is a good idea to only process scans if a reasonable
+     * amount of time has passed. This parameter is particularly useful
+     * when there is a need to process scans while the robot is stationary.
+     * Default value is 3600 (seconds), effectively disabling this parameter.
+     */
+    Parameter<kt_double>* m_pMinimumTimeInterval;
+
+    /**
      * Sets the minimum travel between scans.  If a new scan's position is more than minimumTravelDistance
      * from the previous scan, the mapper will use the data from the new scan. Otherwise, it will discard the
      * new scan if it also does not meet the minimum change in heading requirement.
@@ -1873,6 +1886,7 @@ namespace karto
     // General Parameters
     bool getParamUseScanMatching();
     bool getParamUseScanBarycenter();
+    double getParamMinimumTimeInterval();
     double getParamMinimumTravelDistance();
     double getParamMinimumTravelHeading();
     int getParamScanBufferSize();
@@ -1910,6 +1924,7 @@ namespace karto
     // General Parameters
     void setParamUseScanMatching(bool b);
     void setParamUseScanBarycenter(bool b);
+    void setParamMinimumTimeInterval(double d);
     void setParamMinimumTravelDistance(double d);
     void setParamMinimumTravelHeading(double d);
     void setParamScanBufferSize(int i);

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -2303,6 +2303,13 @@ namespace karto
       return true;
     }
 
+    // test if enough time has passed
+    kt_double timeInterval = pScan->GetTime() - pLastScan->GetTime();
+    if (timeInterval >= m_pMinimumTimeInterval->GetValue())
+    {
+      return true;
+    }
+
     Pose2 lastScannerPose = pLastScan->GetSensorAt(pLastScan->GetOdometricPose());
     Pose2 scannerPose = pScan->GetSensorAt(pScan->GetOdometricPose());
 

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -1676,6 +1676,18 @@ namespace karto
         "scans.",
         true, GetParameterManager());
 
+    m_pMinimumTimeInterval = new Parameter<kt_double>(
+        "MinimumTimeInterval",
+        "Sets the minimum time between scans. If a new scan's time stamp is "
+        "longer than MinimumTimeInterval from the previously processed scan, "
+        "the mapper will use the data from the new scan. Otherwise, it will "
+        "discard the new scan if it also does not meet the minimum travel "
+        "distance and heading requirements. For performance reasons, it is "
+        "generally it is a good idea to only process scans if a reasonable "
+        "amount of time has passed. This parameter is particularly useful "
+        "when there is a need to process scans while the robot is stationary.",
+        3600, GetParameterManager());
+
     m_pMinimumTravelDistance = new Parameter<kt_double>(
         "MinimumTravelDistance",
         "Sets the minimum travel between scans.  If a new scan's position is "
@@ -1865,6 +1877,11 @@ namespace karto
     return static_cast<bool>(m_pUseScanBarycenter->GetValue());
   }
 
+  double Mapper::getParamMinimumTimeInterval()
+  {
+    return static_cast<double>(m_pMinimumTimeInterval->GetValue());
+  }
+
   double Mapper::getParamMinimumTravelDistance()
   {
     return static_cast<double>(m_pMinimumTravelDistance->GetValue());
@@ -2011,6 +2028,11 @@ namespace karto
   void Mapper::setParamUseScanBarycenter(bool b)
   {
     m_pUseScanBarycenter->SetValue((kt_bool)b);
+  }
+
+  void Mapper::setParamMinimumTimeInterval(double d)
+  {
+    m_pMinimumTimeInterval->SetValue((kt_double)d);
   }
 
   void Mapper::setParamMinimumTravelDistance(double d)


### PR DESCRIPTION
This PR is tied to ros-perception/slam_karto#11 ⚠️ 

Adds a new parameter, `MinimumTimeInterval`, which is similar in spirit to the existing `MinimumTravelDistance` and `MinimumTravelHeading`. It's also similar to GMapping's `temporalUpdate` parameter. The new parameter defaults to `3600` (seconds), which effectively disables it. (Instead, I can make it such that negative values disable it, like in GMapping.)

From the header file documentation:

>  Sets the minimum time between scans. If a new scan's time stamp is
>  longer than MinimumTimeInterval from the previously processed scan,
>  the mapper will use the data from the new scan. Otherwise, it will
>  discard the new scan if it also does not meet the minimum travel
>  distance and heading requirements. For performance reasons, it is
>  generally it is a good idea to only process scans if a reasonable
>  amount of time has passed. This parameter is particularly useful
>  when there is a need to process scans while the robot is stationary.
>  Default value is 3600 (seconds), effectively disabling this parameter.

Here are two quick videos demonstrating the usefulness of such as parameter when the robot is stationary but there is a need for processing laser scans:
### Before (not very interesting and laser scans go to waste):

```
minimum_travel_distance:  0.30    # [m]
minimum_travel_heading:   0.50    # [rad]
```

[![Without the new parameter](https://img.youtube.com/vi/3rg0KmSsDi4/0.jpg)](https://youtu.be/3rg0KmSsDi4)
### After (Karto processes laser scans while the robot is stationary):

```
minimum_time_interval:    1.0     # [sec]
minimum_travel_distance:  0.30    # [m]
minimum_travel_heading:   0.50    # [rad]
```

[![With the new parameter](https://img.youtube.com/vi/aT9oaF4D85M/0.jpg)](https://youtu.be/aT9oaF4D85M)
