### PR TITLE
[Windows][melodic] Fix Windows build break

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,17 @@ catkin_package(
     karto
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DKARTO_DYNAMIC)
+endif()
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 add_library(karto SHARED src/Karto.cpp src/Mapper.cpp)
 target_link_libraries(karto ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS karto
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )


### PR DESCRIPTION
This is to fix the Windows build break (based on the installation from https://aka.ms/ros).

* Fix install path by following the catkin guidance. (http://docs.ros.org/kinetic/api/catkin/html/howto/format1/building_libraries.html#installing)
* Fix Boost_INCLUDE_DIRS missing from include_directories.
* Fix KARTO_DYNAMIC should be defined if BUILD_SHARED_LIBS is globally enabled.