### PR TITLE
Melodic: build status badges Indigo is EOL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Catkinized ROS Package of the OpenKarto Library (LGPL3)
 
 # Status
 
- * Devel Job Status: [![Build Status](http://build.ros.org/buildStatus/icon?job=Idev__open_karto__ubuntu_trusty_amd64)](http://build.ros.org/job/Idev__open_karto__ubuntu_trusty_amd64/)
- * AMD64 Debian Job Status: [![Build Status](http://build.ros.org/buildStatus/icon?job=Jbin_uT64__open_karto__ubuntu_trusty_amd64__binary)](http://build.ros.org/job/Jbin_uT64__open_karto__ubuntu_trusty_amd64__binary)
+ * Devel Job Status: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdev__open_karto__ubuntu_bionic_amd64)](http://build.ros.org/job/Mdev__open_karto__ubuntu_bionic_amd64/)
+ * AMD64 Debian Job Status: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__open_karto__ubuntu_bionic_amd64__binary)](http://build.ros.org/job/Mbin_uB64__open_karto__ubuntu_bionic_amd64__binary/)


### PR DESCRIPTION
Just a minor thing. I was visiting the repo because I noticed some gcc warnings.