### PR TITLE
add Hokuyo configuration in `SetAngularResolution` function

### DIFF
--- a/include/open_karto/Karto.h
+++ b/include/open_karto/Karto.h
@@ -3898,6 +3898,34 @@ namespace karto
           throw Exception(stream.str());
         }
       }
+      else if (m_pType->GetValue() == LaserRangeFinder_Hokuyo_UTM_30LX)
+      {
+        if (math::DoubleEqual(angularResolution, math::DegreesToRadians(0.25)))
+        {
+          m_pAngularResolution->SetValue(math::DegreesToRadians(0.25));
+        }
+        else
+        {
+          std::stringstream stream;
+          stream << "Invalid resolution for Hokuyo_UTM_30LX:  ";
+          stream << angularResolution;
+          throw Exception(stream.str());
+        }
+      }
+      else if (m_pType->GetValue() == LaserRangeFinder_Hokuyo_URG_04LX)
+      {
+        if (math::DoubleEqual(angularResolution, math::DegreesToRadians(0.352)))
+        {
+          m_pAngularResolution->SetValue(math::DegreesToRadians(0.352));
+        }
+        else
+        {
+          std::stringstream stream;
+          stream << "Invalid resolution for Hokuyo_URG_04LX:  ";
+          stream << angularResolution;
+          throw Exception(stream.str());
+        }
+      }
       else
       {
         throw Exception("Can't set angular resolution, please create a LaserRangeFinder of type Custom");


### PR DESCRIPTION
Karto has five kinds of lidar parameter configurations (LMS100, LMS200, LMS291, UTM_30LX, URG_04LX), but there are only the first three configurations in the `SetAngularResolution` function, so I added the parameter configuration of UTM_30LX and URG_04LX.