### PR TITLE
fix parameter passing bug of first link to other robots

### DIFF
--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -1195,7 +1195,7 @@ namespace karto
         kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan(pScan,
                                                                   pSensorManager->GetScans(rCandidateSensorName),
                                                                   bestPose, covariance);
-        LinkScans(pScan, pSensorManager->GetScan(rCandidateSensorName, 0), bestPose, covariance);
+        LinkScans(pSensorManager->GetScan(rCandidateSensorName, 0), pScan, bestPose, covariance);
 
         // only add to means and covariances if response was high "enough"
         if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue())


### PR DESCRIPTION
LinkScans in Mapper.cpp is 
`void MapperGraph::LinkScans(LocalizedRangeScan* pFromScan, LocalizedRangeScan* pToScan, const Pose2& rMean, const Matrix3& rCovariance)`

but line 1198 in Mapper.cpp reversed the `pscan` and `pSensorManager->GetScan(rCandidateSensorName, 0)` parameters.

The correct order should be as shown on line 1171.