### PR TITLE
Fix -Wdelete-non-virtual-dtor and -Wreorder warnings

### DIFF
--- a/include/open_karto/Karto.h
+++ b/include/open_karto/Karto.h
@@ -5510,8 +5510,8 @@ namespace karto
      */
     LocalizedRangeScanWithPoints(const Name& rSensorName, const RangeReadingsVector& rReadings,
         const PointVectorDouble& rPoints)
-        : m_Points(rPoints),
-          LocalizedRangeScan(rSensorName, rReadings)
+        : LocalizedRangeScan(rSensorName, rReadings),
+          m_Points(rPoints)
     {
     }
 
@@ -5602,6 +5602,11 @@ namespace karto
       : m_pOccupancyGrid(pGrid)
     {
     }
+
+    /**
+     * Destructor
+     */
+    virtual ~CellUpdater() = default;
 
     /**
      * Updates the cell at the given index based on the grid's hits and pass counters


### PR DESCRIPTION
When importing karto.h into another project, I was getting the following warnings.

```
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h: In constructor ‘karto::LocalizedRangeScanWithPoints::LocalizedRangeScanWithPoints(const karto::Name&, const RangeReadingsVector&, const PointVectorDouble&)’:
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h:5589:29: warning: ‘karto::LocalizedRangeScanWithPoints::m_Points’ will be initialized after [-Wreorder]
     const PointVectorDouble m_Points;
                             ^~~~~~~~
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h:5514:52: warning:   base ‘karto::LocalizedRangeScan’ [-Wreorder]
           LocalizedRangeScan(rSensorName, rReadings)
                                                    ^
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h:5511:5: warning:   when initialized here [-Wreorder]
     LocalizedRangeScanWithPoints(const Name& rSensorName, const RangeReadingsVector& rReadings,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h: In destructor ‘virtual karto::OccupancyGrid::~OccupancyGrid()’:
/home/turtlebot/cobalt/forked_ws/src/open_karto/include/open_karto/Karto.h:5657:14: warning: deleting object of polymorphic class type ‘karto::CellUpdater’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
       delete m_pCellUpdater;
              ^~~~~~~~~~~~~~
```

This commit fixes these warnings by adding a default destructor and reordering the initialization.