### PR TITLE
update destructor to not use c11 feature

### DIFF
--- a/include/open_karto/Karto.h
+++ b/include/open_karto/Karto.h
@@ -5606,7 +5606,7 @@ namespace karto
     /**
      * Destructor
      */
-    virtual ~CellUpdater() = default;
+    virtual ~CellUpdater() {}
 
     /**
      * Updates the cell at the given index based on the grid's hits and pass counters


### PR DESCRIPTION
Alternative to #25, fixes warning introduced in #24